### PR TITLE
fix: add output standalone to next.config.ts

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: 'standalone',
 };
 
 export default nextConfig;


### PR DESCRIPTION
Required for Dockerfile COPY .next/standalone to work. Without this, Next.js does not generate the standalone build output.